### PR TITLE
Add link from repo to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # GUAC Documentation
 
-These docs are currently under construction.
+Documentation is rendered [here](https://docs.guac.sh/).


### PR DESCRIPTION
I was looking for something in the GUAC docs and realized that there isn't a link from the repo to the docs. 