### PR TITLE
add dependency on goreleaser

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -41,6 +41,7 @@ GUAC components work together]({{ site.baseurl }}{%link guac-components.md %}).
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Git](https://git-scm.com/downloads)
 - [Go](https://go.dev/doc/install)
+- [GoReleaser](https://goreleaser.com/)
 - [Make](https://www.gnu.org/software/make/)
 - [jq](https://stedolan.github.io/jq/download/) (optional)
 


### PR DESCRIPTION
I was trying to build the latest `main` and got hit with this:
```
% make container                                                                                     
goreleaser is not installed. Please install goreleaser and try again.                                                    
make: *** [check-goreleaser-tool-check] Error 1                                                                          
```

Looks like we made the dependency explicit here: https://github.com/guacsec/guac/commit/fcedbd05fcf03368f3b9ccd474e6b8eb7b8695ef#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L100