### PR TITLE
Correct requirements

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -40,10 +40,10 @@ GUAC components work together]({{ site.baseurl }}{%link guac-components.md %}).
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Git](https://git-scm.com/downloads)
-- [Go](https://go.dev/doc/install)
+- [Go](https://go.dev/doc/install) (v1.21)
 - [GoReleaser](https://goreleaser.com/)
 - [Make](https://www.gnu.org/software/make/)
-- [jq](https://stedolan.github.io/jq/download/) (optional)
+- [jq](https://stedolan.github.io/jq/download/)
 
 ## Step 1: Clone GUAC
 


### PR DESCRIPTION
- The required version of Golang is 1.21.
- jq is not optional, it is a requirement.