### PR TITLE
Update docker-compose to docker compose

### DIFF
--- a/expanding-your-view.md
+++ b/expanding-your-view.md
@@ -680,5 +680,5 @@ vulnerability.
 To delete all the GUAC resources, run:
 
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/patch-cli.md
+++ b/patch-cli.md
@@ -164,7 +164,7 @@ as well.
 To delete the all the GUAC components run:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 ## Conclusion

--- a/querying-via-cli.md
+++ b/querying-via-cli.md
@@ -217,5 +217,5 @@ to create more tools such as these quickly and easily!
 To delete the all the GUAC components run:
 
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/setup.md
+++ b/setup.md
@@ -74,13 +74,13 @@ GUAC components work together]({{ site.baseurl }}{%link guac-components.md %}).
 1. In another terminal, from the `guac-compose` directory, run:
 
    ```bash
-   docker-compose up --force-recreate
+   docker compose up --force-recreate
    ```
 
 2. Verify that GUAC is running:
 
    ```bash
-   docker-compose ls --filter "name=guac"
+   docker compose ls --filter "name=guac"
    ```
 
    You should see:
@@ -90,7 +90,7 @@ GUAC components work together]({{ site.baseurl }}{%link guac-components.md %}).
    guac                running(7)          /Users/lumb/go/src/github.com/guacsec/guac/docker-compose.yml
    ```
 
-   **If you don’t see the above,** run `docker-compose down` and try starting up
+   **If you don’t see the above,** run `docker compose down` and try starting up
    GUAC again. Because Docker Compose caches the containers used, the unclean
    state can cause issues.
 


### PR DESCRIPTION
Update the docs to use "docker compose" instead of "docker-compose" to match the commands in the makefile (e.g. [[here](https://github.com/guacsec/guac/blob/810b0a983849e87ee433606fa0329ac27350400e/Makefile#L137)]) and because Docker Compose V1 (with the hyphen) is being deprecated. 