### PR TITLE
Revert "docker-compose - backend selection on startup"

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -88,7 +88,7 @@ A video format of these setup instructions is available here:
 1. In another terminal, from the `guac-compose` directory, run:
 
    ```bash
-   docker compose -f docker-compose.yml -f container_files/mem.yaml up --force-recreate
+   docker compose up --force-recreate
    ```
 
 1. Verify that GUAC is running:


### PR DESCRIPTION
revert changes from #106 until a new release has been cut from guac capturing the changes to the docker-compose. 

@desmax74 revert this change as I mistakenly merged these changes. We will have to wait for the next release where we capture the docker-compose files in the release to update the docs. The docs refer to the latest release for the docker-compose and not guac main.