### PR TITLE
1434 docker compose split

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -88,7 +88,7 @@ A video format of these setup instructions is available here:
 1. In another terminal, from the `guac-compose` directory, run:
 
    ```bash
-   docker compose up --force-recreate
+   docker compose -f docker-compose.yml -f container_files/mem.yaml up --force-recreate
    ```
 
 1. Verify that GUAC is running:


### PR DESCRIPTION
See: https://github.com/guacsec/guac-docs/pull/109
and https://github.com/guacsec/guac-docs/pull/106
and https://github.com/guacsec/guac/issues/1435
and  https://github.com/guacsec/guac/issues/1434

The PR [1434](https://github.com/guacsec/guac/issues/1434)  enable the startup of guac with docker compose choosing the backend

    In memory docker compose -f docker-compose.yml -f container_files/mem.yaml up

    Arango docker compose -f docker-compose.yml -f container_files/arango.yaml up

    Ent docker compose -f docker-compose.yml -f container_files/ent.yaml up

    Neo4j docker compose -f docker-compose.yml -f container_files/neo4j.yaml up

In the make file the `make start-service` run the in memory option