### PR TITLE
Bring output of 'docker compose ls --filter "name=guac"' up-to-date

### DIFF
--- a/developing-data-sources.md
+++ b/developing-data-sources.md
@@ -5,10 +5,9 @@ permalink: /developing-below/
 nav_order: 5
 ---
 
-As shown in the [knowing your
-unknowns]({{ site.baseurl }}{%link known-and-unknown.md %}) and [expanding your
-view of the supply chain
-demo]({{ site.baseurl }}{%link expanding-your-view.md %}), GUAC is able to
-ingest from multiple data sources and in multiple formats. If you are
-interesting in building a data source for GUAC, please create a
-[feature request issue](https://github.com/guacsec/guac/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=%5Bfeature%5D+FILL+THIS+IN).
+As shown in the [knowing
+your unknowns]({{ site.baseurl }}{%link known-and-unknown.md %}) and [expanding
+your view of the supply chain
+demo]({{ site.baseurl }}{%link expanding-your-view.md %}), GUAC is able to ingest
+from multiple data sources and in multiple formats. If you are interesting in building
+a data source for GUAC, please create a [feature request issue](https://github.com/guacsec/guac/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=%5Bfeature%5D+FILL+THIS+IN).

--- a/developing-tools.md
+++ b/developing-tools.md
@@ -6,6 +6,6 @@ has_children: true
 nav_order: 3
 ---
 
-As shown in the [GUAC demos]({{ site.baseurl }}{%link guac-use-cases.md %}), it
-is possible to develop many utilities through the use of GUAC. This section
-talks about how you can do that leveraging GUAC's GraphQL API.
+As shown in the [GUAC demos]({{ site.baseurl }}{%link guac-use-cases.md %}), it is
+possible to develop many utilities through the use of GUAC. This section talks about
+how you can do that leveraging GUAC's GraphQL API.

--- a/expanding-your-view.md
+++ b/expanding-your-view.md
@@ -660,9 +660,9 @@ This information came from the OSV certifier service that is constantly running
 within GUAC. From this, we can see that two versions of
 `github.com/prometheus/client_golang` contain the same `ghsa-cg3q-j54f-5p7p`. In
 the [vulnerability CLI demo]({{ site.baseurl }}{%link
-querying-via-cli.md %}), we can use this information to determine if there is a path
-between this and the version of Vault we are using. Here is a quick look at what
-the visualization would look like for that:
+querying-via-cli.md %}), we can use this information to determine if there is a
+path between this and the version of Vault we are using. Here is a quick look at
+what the visualization would look like for that:
 
 ![Visualization of data](assets/images/expandviewvisualization.png)
 

--- a/graphql.md
+++ b/graphql.md
@@ -17,8 +17,7 @@ of API changes. To get started, consult
 [the official documentation](https://graphql.org/learn/).
 
 This documents provides some insight into how the GraphQL API matches the [GUAC
-ontology]({{ site.baseurl }}{%link guac-ontology.md %}) and its
-[definition]({{ site.baseurl }}{%link guac-ontology-definition.md %}).
+ontology]({{ site.baseurl }}{%link guac-ontology.md %}) and its [definition]({{ site.baseurl }}{%link guac-ontology-definition.md %}).
 
 Note: the GraphQL definitions are not yet stable, they might change in future
 code changes. To get an up to date view of the definitions, you can use one of
@@ -29,9 +28,8 @@ the following:
 - Look at the generated Go documentation using `godoc` and analyzing the
   `guacsec/guac/pkg/assembler/graphql/model` package.
 - Open the playground by passing `--gql-debug` to [`guacgql`
-  component]({{ site.baseurl }}{%link setup.md %}), then consult the
-  documentation tab of the
-  [Graphiql editor](https://github.com/graphql/graphiql).
+  component]({{ site.baseurl }}{%link setup.md %}), then consult the documentation
+  tab of the [Graphiql editor](https://github.com/graphql/graphiql).
 - Use [GraphQL Voyager](https://ivangoncharov.github.io/graphql-voyager/). You
   can load the schema by using the introspection query on the `guacgql` server
   or by concatenating all the source of truth documents.
@@ -646,10 +644,9 @@ definition for these as of now.
 
 Each GraphQL type defined so far has a semantic meaning, tied to the [GUAC
 ontology]({{ site.baseurl }}{%link guac-ontology.md %}). However, in some cases,
-users might want to see what GraphQL types are linked to a specific type, or
-they might want to find a link between two different nodes. For these cases, we
-currently provide an experimental interface to get topological information about
-the GUAC graph.
+users might want to see what GraphQL types are linked to a specific type, or they
+might want to find a link between two different nodes. For these cases, we currently
+provide an experimental interface to get topological information about the GUAC graph.
 
 Note: These definitions are subject to change and might be removed in future
 versions of GUAC. Treat this interface as experimental.

--- a/guac-components.md
+++ b/guac-components.md
@@ -21,8 +21,8 @@ nav_order: 1
 
 The full GUAC component deployment is a set of asynchronous services that
 combine to form a robust and scaleable pipeline. In some of our [demos]({{
-site.baseurl }}{%link guac-use-cases.md %}), you may have seen these components work
-in concert. Read on to learn more of what goes on behind the hood!
+site.baseurl }}{%link guac-use-cases.md %}), you may have seen these components
+work in concert. Read on to learn more of what goes on behind the hood!
 
 ## GUAC Components
 
@@ -76,8 +76,8 @@ the OSV vulnerability.
 
 #### Ingestor
 
-Ingestors take in documents and parse them into the [GUAC data
-model/ontology]({{ site.baseurl }}{%link guac-ontology.md %}). This process
+Ingestors take in documents and parse them into the [GUAC
+data model/ontology]({{ site.baseurl }}{%link guac-ontology.md %}). This process
 extracts meaning from documents and translates them into a common reasoning
 model (GUAC ontology). In the process, it also finds identifiers of interest
 that it passes to the CollectSub service to request additional information for.

--- a/guac-ontology-definition.md
+++ b/guac-ontology-definition.md
@@ -15,8 +15,8 @@ the [GraphQL documentation]({{ site.baseurl }}{%link graphql.md %}).
 
 ## Overview
 
-The [GUAC Onlotogy]({{ site.baseurl }}{%link guac-ontology.md %}) document
-defines the 3 structures as the software tree, evidence tree, and actor tree.
+The [GUAC Onlotogy]({{ site.baseurl }}{%link guac-ontology.md %}) document defines
+the 3 structures as the software tree, evidence tree, and actor tree.
 
 - **Software Tree:** A factual structure that describes software entities. They
   communicate both physical (e.g. artifact and hashes) and logical (e.g. pURL)
@@ -129,8 +129,7 @@ An example of a predicate is:
   - source ( string )
   - collector ( string )
 
-For a list of all predicates, please refer to the [GraphQL
-documentation]({{ site.baseurl }}{%link graphql.md %}).
+For a list of all predicates, please refer to the [GraphQL documentation]({{ site.baseurl }}{%link graphql.md %}).
 
 ## GUAC Actor Tree (Not in v0.1 BETA)
 

--- a/guac-use-cases.md
+++ b/guac-use-cases.md
@@ -10,8 +10,7 @@ nav_order: 3
 # GUAC demos
 
 The following demos show you a few ways that you can use GUAC. If you want to
-visualize the output from the demos, you can [install the GUAC
-Visualizer]({{ site.baseurl }}{%link
+visualize the output from the demos, you can [install the GUAC Visualizer]({{ site.baseurl }}{%link
 guac-visualizer.md %}).
 
 If you want to develop functionality beyond the demos, see ["Developing tools on

--- a/index.md
+++ b/index.md
@@ -23,18 +23,18 @@ audit, policy, risk management, and even developer assistance.
 
 ![GUAC Visualizer](assets/images/supplychain_dependencies_graph.png)
 
-The [GUAC Visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) explores
-the various nodes and relationships of GUAC. A particular node can be searched
-for, or you can click through each node to discover its relationships. Most CLI
-commands below also provide a visualizer link to load the results of the command
-into the visualizer.
+The [GUAC Visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) explores the
+various nodes and relationships of GUAC. A particular node can be searched for, or
+you can click through each node to discover its relationships. Most CLI commands
+below also provide a visualizer link to load the results of the command into the
+visualizer.
 
 ### Search for vulnerabilities via transitive dependencies in the GUAC graph
 
 The [Query Vulnerability via CLI Demo]({{ site.baseurl }}{%link
-querying-via-cli.md %}) covers the `guacone query vuln` command. Given a Package-URL,
-this command searches the GUAC graph for any paths leading to any known vulnerabilities
-and produces a report. Example:
+querying-via-cli.md %}) covers the `guacone query vuln` command. Given a
+Package-URL, this command searches the GUAC graph for any paths leading to any
+known vulnerabilities and produces a report. Example:
 
 ```bash
 +-------------+-----------+---------------------------------------+

--- a/known-and-unknown.md
+++ b/known-and-unknown.md
@@ -31,8 +31,8 @@ picture of your software supply chain. With GUAC you can easily determine your:
 In the ["Expanding your view of the software supply chain" demo]({{
 site.baseurl }}{%link expanding-your-view.md %}), we went through the process of
 ingesting an SBOM and letting GUAC expand our horizons on what we know about our
-environment autonomously. In this demo, we'll take that information and use it to
-determine what we know and don't know about the artifacts.
+environment autonomously. In this demo, we'll take that information and use it
+to determine what we know and don't know about the artifacts.
 
 ## Requirements
 
@@ -40,8 +40,8 @@ determine what we know and don't know about the artifacts.
   site.baseurl }}{%link setup.md %}). Including the `guacone` binary in your path
   and [GUAC Data](https://github.com/guacsec/guac-data/archive/refs/heads/main.zip)
   extracted to `guac-data-main`.
-- Completion of the [Expanding your view of the software supply chain
-  demo]({{ site.baseurl }}{%link expanding-your-view.md %})
+- Completion of the [Expanding your view of the software supply
+  chain demo]({{ site.baseurl }}{%link expanding-your-view.md %})
 
 ## Ingest GUAC Data (if needed)
 
@@ -355,8 +355,8 @@ and a artifact (algorithm:digest).
 
    **NOTE**: This is just the vulnerability associated with this specific
    package (not taking into account dependencies). For a full in-depth
-   vulnerability search please follow the [Query Vulnerability
-   demo]({{ site.baseurl }}{%link querying-via-cli.md %}).
+   vulnerability search please follow the [Query
+   Vulnerability demo]({{ site.baseurl }}{%link querying-via-cli.md %}).
 
    We also see that in this case, we did not get a `hasSBOM` associated with it.
    Meaning that we do not have any SBOM information related to this package. We

--- a/patch-cli.md
+++ b/patch-cli.md
@@ -33,8 +33,7 @@ resolve a security incident.
   and [GUAC Data](https://github.com/guacsec/guac-data/archive/refs/heads/main.zip)
   ingested.
 
-- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and
-  running.
+- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and running.
 
 ## Step 1: Ingest GUAC Data (if needed)
 

--- a/querying-via-cli.md
+++ b/querying-via-cli.md
@@ -27,8 +27,7 @@ vulnerability.
   and [GUAC Data](https://github.com/guacsec/guac-data/archive/refs/heads/main.zip)
   extracted to `guac-data-main`.
 
-- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and
-  running.
+- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and running.
 
 ## Step 1. Ingest a vulnerability SPDX SBOM
 

--- a/setup-postgres.md
+++ b/setup-postgres.md
@@ -26,8 +26,8 @@ deployment with a PostgreSQL database backend using Docker Compose.
 
 ## Optional - Verify images and binaries
 
-- Follow [Verification of the GUAC images and
-  binaries]({{ site.baseurl }}{%link verification.md %})
+- Follow [Verification of the GUAC images
+  and binaries]({{ site.baseurl }}{%link verification.md %})
 
 ## Step 1: Download GUAC
 

--- a/setup.md
+++ b/setup.md
@@ -16,8 +16,7 @@ Note that these helm charts are still experimental and are hosted in a
 third-party repo and may not be synchronized with the GUAC repo.
 
 This tutorial will walk you through how to deploy a demo-level GUAC, using
-Docker Compose, so that you get just enough components to complete all the [GUAC
-demos]({{ site.baseurl }}{% link guac-use-cases.md %}).
+Docker Compose, so that you get just enough components to complete all the [GUAC demos]({{ site.baseurl }}{% link guac-use-cases.md %}).
 
 ## Setup video
 
@@ -42,8 +41,8 @@ A video format of these setup instructions is available here:
 
 ## Optional - Verify images and binaries
 
-- Follow [Verification of the GUAC images and
-  binaries]({{ site.baseurl }}{%link verification.md %})
+- Follow [Verification of the GUAC images
+  and binaries]({{ site.baseurl }}{%link verification.md %})
 
 ## Step 1: Download GUAC
 

--- a/supply-chain.md
+++ b/supply-chain.md
@@ -41,8 +41,7 @@ site.baseurl }}{%link querying-via-cli.md %})).
   and [GUAC Data](https://github.com/guacsec/guac-data/archive/refs/heads/main.zip)
   extracted to `guac-data-main`.
 
-- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and
-  running.
+- The [GUAC visualizer]({{ site.baseurl }}{%link guac-visualizer.md %}) up and running.
 
 ## Step 1: Set up your organization's software catalog
 


### PR DESCRIPTION
In https://github.com/guacsec/guac/issues/2002 Mike noted that the output in the docs is out-of-date, so I brought it up-to-date here. I hacked up my own output to leave Brandon L's name there because it felt weird putting my own in there when I am not a maintainer of guac.

For posterity, here is what I saw:

```bash
nchelluri@Narsimhams-MBP guac-demo % docker compose ls --filter "name=guac"
NAME                STATUS              CONFIG FILES
guac                running(2)          /Users/nchelluri/dev/guac/docker-compose.yml,/Users/nchelluri/dev/guac/container_files/mem.yaml
guac-demo           running(5)          /Users/nchelluri/dev/guac-demo/guac-demo-compose.yaml
nchelluri@Narsimhams-MBP guac-demo % docker compose ls
NAME                STATUS              CONFIG FILES
container_files     running(1)          /Users/nchelluri/dev/guac/container_files/guac-demo-compose.yaml
guac                running(2)          /Users/nchelluri/dev/guac/docker-compose.yml,/Users/nchelluri/dev/guac/container_files/mem.yaml
guac-demo           running(5)          /Users/nchelluri/dev/guac-demo/guac-demo-compose.yaml
nchelluri@Narsimhams-MBP guac-demo %
```