### PR TITLE
Clarify verification step on setup-install page

### DIFF
--- a/setup-install.md
+++ b/setup-install.md
@@ -50,7 +50,7 @@ nav_order: 1
 1. From the directory you downloaded the `guac-demo-compose.yaml`, run:
 
    ```bash
-   docker compose -f guac-demo-compose.yaml up --force-recreate
+   docker compose -f guac-demo-compose.yaml -p guac up --force-recreate
    ```
 
 1. Verify that GUAC is running:


### PR DESCRIPTION
This PR Fixes #151 by setting a consistent name so the corresponding ls command will match what the user sees regardless of the cwd. 

[Before](https://docs.guac.sh/setup-install/#start-the-guac-server) | [After](https://deploy-preview-152--resonant-wisp-1a517a.netlify.app/setup-install/#start-the-guac-server)