### PR TITLE
Add newlines to make prettier behave

### DIFF
--- a/querying-via-cli.md
+++ b/querying-via-cli.md
@@ -98,9 +98,11 @@ just once.
 
 ## Run the Query Vulnerability CLI
 
-{: .important } This section requires GUAC v0.8.9 or later. If you are using an
-older version of GUAC, please update. If you cannot, then use
-`guacone query vuln` instead of `guacone query vuln (purl|uri)`.
+{: .important }
+
+This section requires GUAC v0.8.9 or later. If you are using an older version of
+GUAC, please update. If you cannot, then use `guacone query vuln` instead of
+`guacone query vuln (purl|uri)`.
 
 Now that our GUAC instance is up and running with up-to-date information on the
 vulnerable image that we ingest, we will look at how we can utilize this data


### PR DESCRIPTION
If you don't have a blank line between the admonition and its text, prettier will helpfully adjust the wrapping so that the admonition and the start of the text are on the same line. This makes it render the admonition literally.

Fixes #155