### PR TITLE
Remove webrick dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,3 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
-gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
-    webrick (1.8.1)
 
 PLATFORMS
   x86_64-linux
@@ -261,7 +260,6 @@ DEPENDENCIES
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
-  webrick (~> 1.7)
 
 BUNDLED WITH
    2.4.12


### PR DESCRIPTION
As far as I can tell, this isn't actually used anywhere, so we avoid a [CVE](https://github.com/guacsec/guac-docs/security/dependabot/12) by dropping it. Upstream says it's [not for use in production](https://github.com/ruby/webrick/issues/145#issuecomment-2359963761) anyway.