### PR TITLE
Address issues discovered by zizmor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,11 +13,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:
@@ -31,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -60,3 +59,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+          pages: write
+          id-token: write 

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+# Ignore the template-injection warning for the site URL because we believe that it's safe
+rules:
+  template-injection:
+    ignore:
+      - pages.yml:42:9


### PR DESCRIPTION
1. Don't persist credentials in the checkout action
2. Scope write permissions to the necessary step
3. Add a zizmor config file to ignore the template-injection warning for the base_path output.