### PR TITLE
Fix pages workflow syntax

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,10 +55,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+      pages: write
+      id-token: write 
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-        permissions: # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-          pages: write
-          id-token: write 
+


### PR DESCRIPTION
As part of a fix for issue #175, I moved the permissions in the step. This is incorrect. So this commit moves it to the job, which appears to be the correct place.