### PR TITLE
Improve CI format check output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Check markdown format
-        run: npx --yes prettier --write --prose-wrap always *.md
-      - name: Check that all markdown is up to date
-        run: git status -s && test -z "$(git status -s)"
+        run: npx --yes prettier --check --prose-wrap always *.md


### PR DESCRIPTION
Instead of writing the formatted files and then using git to compare them, let's just have prettier error with a helpful message when files are mis-formatted.

Fixes #86 