### PR TITLE
Fix docs to point to Apple Silicon releases

### DIFF
--- a/setup-install.md
+++ b/setup-install.md
@@ -28,8 +28,8 @@ nav_order: 1
 
    - Linux x86_64 :
      [`guacone-linux-amd64`](https://github.com/guacsec/guac/releases/latest/download/guacone-linux-amd64)
-   - MacOS x86_64 :
-     [`guacone-darwin-amd64`](https://github.com/guacsec/guac/releases/latest/download/guacone-darwin-amd64)
+   - MacOS ARM64 :
+     [`guacone-darwin-arm64`](https://github.com/guacsec/guac/releases/latest/download/guacone-darwin-arm64)
    - Windows x86_64 :
      [`guacone-windows-amd64.exe`](https://github.com/guacsec/guac/releases/latest/download/guacone-windows-amd64.exe)
 

--- a/setup-postgres.md
+++ b/setup-postgres.md
@@ -38,8 +38,8 @@ deployment with a PostgreSQL database backend using Docker Compose.
 
    - Linux x86_64 :
      [`guaccollect-linux-amd64`](https://github.com/guacsec/guac/releases/latest/download/guaccollect-linux-amd64)
-   - MacOS x86_64 :
-     [`guaccollect-darwin-amd64`](https://github.com/guacsec/guac/releases/latest/download/guaccollect-darwin-amd64)
+   - MacOS ARM64 :
+     [`guaccollect-darwin-arm64`](https://github.com/guacsec/guac/releases/latest/download/guaccollect-darwin-arm64)
    - Windows x86_64 :
      [`guaccollect-windows-amd64.exe`](https://github.com/guacsec/guac/releases/latest/download/guaccollect-windows-amd64.exe)
 


### PR DESCRIPTION
Releases for Intel Macs (x86_64) are not published, the lastest MacOS download link in the docs 404s

This change updates the links to point to the arm64 binaries