### PR TITLE
Update the link to the macOS binary

### DIFF
--- a/certifier-cd.md
+++ b/certifier-cd.md
@@ -37,7 +37,6 @@ align the two systems.
 ## What is and is not Supported
 
 1. **Supported Features**:
-
    - GUAC retrieves detailed license data from ClearlyDefined.
    - Both SBOM-derived and ClearlyDefined license data are preserved, allowing
      users to make manual decisions in case of conflicts.
@@ -54,12 +53,10 @@ align the two systems.
 GUAC integrates with ClearlyDefined in three ways:
 
 1. **Scheduled Certifier Execution**
-
    - Automatically runs at specified intervals to keep the dependency data up to
      date.
 
 2. **On-Demand during SBOM Ingestion**
-
    - Queries ClearlyDefined in real time during the ingestion of SBOMs, which
      may slow down the processing.
 

--- a/guac-configuration.md
+++ b/guac-configuration.md
@@ -17,13 +17,11 @@ scenarios where you might want to change it.
 ### Ent config
 
 - **db-driver**: `postgres`
-
   - **Description**: The driver used for the database connection.
   - **When to Change**: Modify if you need to switch to a different database
     driver.
 
 - **db-address**: `postgres://guac:guac@postgres:5432/guac?sslmode=disable`
-
   - **Description**: The address for connecting to the PostgreSQL database.
   - **When to Change**: Update if your database address changes or if you need
     to enable/disable SSL.
@@ -87,7 +85,6 @@ scenarios where you might want to change it.
 ## Pub/Sub Configuration
 
 - **pubsub-addr**: `nats://localhost:4222`
-
   - **Description**: The address of the NATS server for pub/sub messaging.
   - **When to Change**: Update if your NATS server is hosted elsewhere or uses a
     different port.
@@ -107,31 +104,26 @@ scenarios where you might want to change it.
 ## Certifier Configuration
 
 - **interval**: `20m`
-
   - **Description**: The interval at which the certifier runs.
   - **When to Change**: Adjust based on how frequently you need certification
     checks.
 
 - **last-scan**: `4`
-
   - **Description**: The number of hours since the last scan was run. A value of
     `0` means the scan will run on all packages/sources.
   - **When to Change**: Set to `0` for a full scan or adjust based on your
     scanning frequency needs.
 
 - **certifier-batch-size**: `60000`
-
   - **Description**: The batch size for the package pagination query.
   - **When to Change**: Modify to optimize performance based on your system's
     capabilities.
 
 - **certifier-latency**: `""`
-
   - **Description**: Artificial latency to throttle the certifier.
   - **When to Change**: Use to introduce delays if needed to manage load.
 
 - #### Deps.dev Configuration
-
   - **deps-dev-latency**: `""`
   - **Description**: Artificial latency to throttle deps.dev.
   - **When to Change**: Adjust if you need to manage load on deps.dev queries.
@@ -139,7 +131,6 @@ scenarios where you might want to change it.
 ## Ingestion Configuration
 
 - **add-vuln-on-ingest**: `false`
-
   - **Description**: Whether to query vulnerabilities during ingestion.
   - **When to Change**: Set to `true` if you want to automatically check for
     vulnerabilities during data ingestion.
@@ -152,7 +143,6 @@ scenarios where you might want to change it.
 ## Collector-Subscriber Configuration
 
 - **csub-addr**: `localhost:2782`
-
   - **Description**: The address for the Collector-Subscriber service.
   - **When to Change**: Update if your Collector-Subscriber service is hosted on
     a different address.
@@ -165,17 +155,14 @@ scenarios where you might want to change it.
 ## GraphQL Configuration
 
 - **gql-backend**: `keyvalue`
-
   - **Description**: The backend used for the GraphQL server.
   - **When to Change**: Modify if using a different backend for GraphQL.
 
 - **gql-listen-port**: `8080`
-
   - **Description**: The port on which the GraphQL server listens.
   - **When to Change**: Change if your GraphQL server uses a different port.
 
 - **gql-debug**: `true`
-
   - **Description**: Whether to enable debug mode for the GraphQL server.
   - **When to Change**: Set to `false` in production environments for security.
 
@@ -192,7 +179,6 @@ scenarios where you might want to change it.
 ## Collector Configuration
 
 - **service-poll**: `true`
-
   - **Description**: Whether the collector should poll services.
   - **When to Change**: Set to `false` if polling is not required.
 

--- a/querying-via-cli.md
+++ b/querying-via-cli.md
@@ -125,7 +125,6 @@ In this first example, we will query if our image has any vulnerabilities
 This can be done in two ways.
 
 1. Using the URI from the SBOM
-
    - For CycloneDX this would be the `serialNumber`. For more details refer to
      the CycloneDX documentation found here:
      https://cyclonedx.org/docs/1.5/json/#serialNumber

--- a/setup-install.md
+++ b/setup-install.md
@@ -29,7 +29,7 @@ nav_order: 1
    - Linux x86_64 :
      [`guacone-linux-amd64`](https://github.com/guacsec/guac/releases/latest/download/guacone-linux-amd64)
    - MacOS ARM64 :
-     [`guacone-darwin-arm64`](https://github.com/guacsec/guac/releases/latest/download/guacone-darwin-arm64)
+     [`guacone-darwin-amd64`](https://github.com/guacsec/guac/releases/latest/download/guacone-darwin-amd64)
    - Windows x86_64 :
      [`guacone-windows-amd64.exe`](https://github.com/guacsec/guac/releases/latest/download/guacone-windows-amd64.exe)
 

--- a/setup-install.md
+++ b/setup-install.md
@@ -25,7 +25,6 @@ nav_order: 1
    from the
    [latest GUAC release](https://github.com/guacsec/guac/releases/latest) if you
    have not already done so. For example:
-
    - Linux x86_64 :
      [`guacone-linux-amd64`](https://github.com/guacsec/guac/releases/latest/download/guacone-linux-amd64)
    - MacOS ARM64 :

--- a/setup-postgres.md
+++ b/setup-postgres.md
@@ -33,7 +33,6 @@ deployment with a PostgreSQL database backend using Docker Compose.
    architecture from the
    [latest GUAC release](https://github.com/guacsec/guac/releases/latest) if you
    have not already done so. For example:
-
    - Linux x86_64 :
      [`guaccollect-linux-amd64`](https://github.com/guacsec/guac/releases/latest/download/guaccollect-linux-amd64)
    - MacOS ARM64 :


### PR DESCRIPTION
This essentially undoes f5e0518 (#197) because the binary name has changed again. See guacsec/guac#2730 for more information.

Fixes #208 
Fixes guacsec/guac#2729