### PR TITLE
Do some cleanup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ callouts:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Content under the <a href=\"https://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 International license</a>. Code under the <a href=\"https://opensource.org/license/mit\">MIT license</a>. Copyright &copy; 2024 GUAC a Series of LF Projects, LLC. For web site terms of use, trademark policy and other project policies please see <a href=\"https://lfprojects.org/\">https://lfprojects.org/</a>"
+footer_content: "Content under the <a href=\"https://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 International license</a>. Code under the <a href=\"https://opensource.org/license/mit\">MIT license</a>. Copyright &copy; GUAC a Series of LF Projects, LLC. For web site terms of use, trademark policy and other project policies please see <a href=\"https://lfprojects.org/\">https://lfprojects.org/</a>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/index.md
+++ b/index.md
@@ -4,11 +4,11 @@ layout: home
 nav_order: 1
 ---
 
-`[under_construction.gif]`
+# GUAC Documentation
 
 This is the documentation for the [GUAC umbrella project](https://guac.sh). Our
 two core projects are:
 
 - [Graph for Understanding Artifact
   Composition]({{ site.baseurl}}{%link guac/index.md %}) (GUAC)
-- Trustify (docs coming)
+- [Trustify]({{ site.baseurl }}{% link trustify/index.md %})


### PR DESCRIPTION
1. Add the link to Trustify docs
2. Remove the year from the copyright statement (not required under the
Berne Convention, so let's just not have to worry about keeping it
up-to-date.)

Signed-off-by: Ben Cotton <ben@kusari.dev>