### PR TITLE
docs: Scorecard-certifier

### DIFF
--- a/guac/certifier-scorecard.md
+++ b/guac/certifier-scorecard.md
@@ -44,6 +44,7 @@ actionable security insights.
    - Fetches pre-computed results from the OpenSSF Scorecard API
    - Falls back to computing the scorecard with the scorecard library when the
      API request fails
+   - With `--compute`, skips the API entirely and only computes locally
 
 3. **Data Ingestion**:
    - Converts scorecard results to structured JSON format
@@ -65,6 +66,7 @@ guaccollect scorecard [options]
 | ---------------------------- | -------------------------------------------------------------- | ------------------- |
 | `--certifier-batch-size int` | Sets the batch size for pagination query for the certifier     | 60000               |
 | `--certifier-latency string` | Sets artificial latency on the certifier (e.g., m, h, s, etc.) | Not enabled (empty) |
+| `--compute`                  | Compute scores locally only, skipping the Scorecard API         | false               |
 | `-h, --help`                 | Help for scorecard                                             |                     |
 | `--interval string`          | Polling interval (e.g., m, h, s, etc.)                         | 5m                  |
 | `--service-poll`             | Enable polling mode                                            | false               |
@@ -92,6 +94,16 @@ export GITHUB_AUTH_TOKEN=your_github_token
 # Run the scorecard certifier
 guaccollect scorecard
 ```
+
+### Local Computation Only
+
+```bash
+# Skip the Scorecard API and compute every score locally.
+# Requires GITHUB_AUTH_TOKEN; the certifier exits at startup if it is unset.
+guaccollect scorecard --compute
+```
+
+Useful for air-gapped networks or repositories the public API has never scanned.
 
 ### Polling Mode
 
@@ -133,7 +145,8 @@ Error: GITHUB_AUTH_TOKEN is not set
 ```
 
 **Solution**: Set the `GITHUB_AUTH_TOKEN` environment variable with a valid
-GitHub token.
+GitHub token. Without `--compute` this is only a warning at startup, since the
+API path needs no token; with `--compute` it is a hard error.
 
 ### Rate Limiting
 

--- a/guac/certifier-scorecard.md
+++ b/guac/certifier-scorecard.md
@@ -44,7 +44,7 @@ actionable security insights.
    - Fetches pre-computed results from the OpenSSF Scorecard API
    - Falls back to computing the scorecard with the scorecard library when the
      API request fails
-   - With `--compute`, skips the API entirely and only computes locally
+   - With `--compute`, computes by skips the API entirely 
 
 3. **Data Ingestion**:
    - Converts scorecard results to structured JSON format
@@ -66,7 +66,7 @@ guaccollect scorecard [options]
 | ---------------------------- | -------------------------------------------------------------- | ------------------- |
 | `--certifier-batch-size int` | Sets the batch size for pagination query for the certifier     | 60000               |
 | `--certifier-latency string` | Sets artificial latency on the certifier (e.g., m, h, s, etc.) | Not enabled (empty) |
-| `--compute`                  | Compute scores locally only, skipping the Scorecard API         | false               |
+| `--compute`                  | Compute scores by skipping the Scorecard API         | false               |
 | `-h, --help`                 | Help for scorecard                                             |                     |
 | `--interval string`          | Polling interval (e.g., m, h, s, etc.)                         | 5m                  |
 | `--service-poll`             | Enable polling mode                                            | false               |
@@ -86,7 +86,7 @@ guaccollect scorecard [options]
 ### Basic Usage
 
 ```bash
-# Set GitHub token (used by the local computation fallback)
+# Set GitHub token (used by the computation fallback)
 export GITHUB_AUTH_TOKEN=your_github_token
 ```
 
@@ -95,10 +95,10 @@ export GITHUB_AUTH_TOKEN=your_github_token
 guaccollect scorecard
 ```
 
-### Local Computation Only
+### Computation by skipping API
 
 ```bash
-# Skip the Scorecard API and compute every score locally.
+# Skip the Scorecard API and compute every score .
 # Requires GITHUB_AUTH_TOKEN; the certifier exits at startup if it is unset.
 guaccollect scorecard --compute
 ```
@@ -130,7 +130,7 @@ guaccollect scorecard \
 - Currently supports GitHub repositories only
 - Requires valid commit SHA or tag reference
 - Results depend on repository accessibility and structure
-- The local computation fallback requires a GitHub authentication token, is
+- The computation fallback requires a GitHub authentication token, is
   slower for large repositories, and may hit GitHub API rate limits at high
   volume
 

--- a/guac/certifier-scorecard.md
+++ b/guac/certifier-scorecard.md
@@ -66,7 +66,7 @@ guaccollect scorecard [options]
 | ---------------------------- | -------------------------------------------------------------- | ------------------- |
 | `--certifier-batch-size int` | Sets the batch size for pagination query for the certifier     | 60000               |
 | `--certifier-latency string` | Sets artificial latency on the certifier (e.g., m, h, s, etc.) | Not enabled (empty) |
-| `--compute`                  | Compute scores by skipping the Scorecard API         | false               |
+| `--compute`                  | Compute scores by skipping the Scorecard API                   | false               |
 | `-h, --help`                 | Help for scorecard                                             |                     |
 | `--interval string`          | Polling interval (e.g., m, h, s, etc.)                         | 5m                  |
 | `--service-poll`             | Enable polling mode                                            | false               |

--- a/guac/certifier-scorecard.md
+++ b/guac/certifier-scorecard.md
@@ -130,9 +130,8 @@ guaccollect scorecard \
 - Currently supports GitHub repositories only
 - Requires valid commit SHA or tag reference
 - Results depend on repository accessibility and structure
-- The computation fallback requires a GitHub authentication token, is
-  slower for large repositories, and may hit GitHub API rate limits at high
-  volume
+- The computation fallback requires a GitHub authentication token, is slower for
+  large repositories, and may hit GitHub API rate limits at high volume
 
 ## Error Handling
 

--- a/guac/certifier-scorecard.md
+++ b/guac/certifier-scorecard.md
@@ -44,7 +44,7 @@ actionable security insights.
    - Fetches pre-computed results from the OpenSSF Scorecard API
    - Falls back to computing the scorecard with the scorecard library when the
      API request fails
-   - With `--compute`, computes by skips the API entirely 
+   - With `--compute`, computes the scores using the scorecard package
 
 3. **Data Ingestion**:
    - Converts scorecard results to structured JSON format
@@ -66,7 +66,7 @@ guaccollect scorecard [options]
 | ---------------------------- | -------------------------------------------------------------- | ------------------- |
 | `--certifier-batch-size int` | Sets the batch size for pagination query for the certifier     | 60000               |
 | `--certifier-latency string` | Sets artificial latency on the certifier (e.g., m, h, s, etc.) | Not enabled (empty) |
-| `--compute`                  | Compute scores by skipping the Scorecard API                   | false               |
+| `--compute`                  | computes the scores using the scorecard package.               | false               |
 | `-h, --help`                 | Help for scorecard                                             |                     |
 | `--interval string`          | Polling interval (e.g., m, h, s, etc.)                         | 5m                  |
 | `--service-poll`             | Enable polling mode                                            | false               |
@@ -98,7 +98,7 @@ guaccollect scorecard
 ### Computation by skipping API
 
 ```bash
-# Skip the Scorecard API and compute every score .
+# computes the scores using the scorecard package
 # Requires GITHUB_AUTH_TOKEN; the certifier exits at startup if it is unset.
 guaccollect scorecard --compute
 ```


### PR DESCRIPTION
Document the new --compute flag on the scorecard-collector.
Default behaviour is unchanged: the collector hits the Scorecard API first and falls back to computing the score with the scorecard package if that call fails.
--compute makes the fail-fast path (the older, local-computation method) opt-in — it skips the Scorecard API entirely and computes the score with the scorecard package only. This path needs a GITHUB_AUTH_TOKEN.

[PR](https://github.com/guacsec/guac/issues/3013#event-29528021426)